### PR TITLE
Changed print syntax in orque.py

### DIFF
--- a/orque.py
+++ b/orque.py
@@ -41,7 +41,7 @@ while True:
 	if config.pL[0].command == "exit":
 		break
 	else:
-		config.pL[0].parseCommand()
+		print(config.pL[0].parseCommand())
 
 #Timer logic code (To be implemented later)
 '''


### PR DESCRIPTION
Since output messages are being returned from the Player class instead of printed directly, config.pL[0].parseComand() has been placed in a print statement in order to print messages to the console.